### PR TITLE
corrección de completar orden con botón de continuar, y visualización …

### DIFF
--- a/app/Services/Order/OrderActionService.php
+++ b/app/Services/Order/OrderActionService.php
@@ -581,7 +581,7 @@ class OrderActionService
 
                 $quantityExpiration = 0;
                 $lots = $detail->product->lots->sortBy('expiration_date');
-
+                   
 
                 foreach ($lots as $lot) {
                     if ($quantityToReduce <= 0) {
@@ -589,6 +589,7 @@ class OrderActionService
                     }
 
                     $taken = 0;
+                   //  dd($lot->quantity >= $quantityToReduce);
                     if ($lot->quantity >= $quantityToReduce) {
                         $taken = $quantityToReduce;
                         $lot->quantity -= $quantityToReduce;
@@ -773,10 +774,11 @@ class OrderActionService
                 $newPendingOrder = $reservedOrder;
             }
 
-
+            $orderId->load(['seller', 'client', 'details.product']);
             DB::commit();
             return [
                 'order' => $newPendingOrder,
+                'orderCompletada' => $orderId,
             ];
         } catch (\Throwable $e) {
             DB::rollBack();

--- a/resources/js/components/dialogs/BuysModal.vue
+++ b/resources/js/components/dialogs/BuysModal.vue
@@ -628,9 +628,8 @@ const handleCompletePurchase = () => {
     } else {
       currentProgress.value = 100;
     }
-  } else {
-    // Cuando currentProgress === 100, ejecutar la lógica de completar la compra
-    emit(
+
+     emit(
       "purchase-completed",
       props.orderData.id,
       payments.value,
@@ -642,6 +641,21 @@ const handleCompletePurchase = () => {
         spe: props.orderData?.client?.is_spe || false,
       }
     );
+
+  } else {
+    // Cuando currentProgress === 100, ejecutar la lógica de completar la compra
+   /* emit(
+      "purchase-completed",
+      props.orderData.id,
+      payments.value,
+      hasCreditPayment.value,
+      changeAmountInCOP.value,
+      changeAmountInUSD.value,
+      {
+        invoice_switch: invoiceSwitch.value,
+        spe: props.orderData?.client?.is_spe || false,
+      }
+    );*/
     // NO cerrar el modal aquí, solo mostrar el ticket
   }
 };
@@ -678,7 +692,8 @@ const logoSrc = computed(() => {
 const handlePrintTicket = async () => {
   // La orden ya fue completada cuando se hizo clic en "Continuar"
   // Aquí solo imprimimos el ticket
-  await nextTick();
+   emit("printTicke-completed");
+/*await nextTick();
   const printContents = document.getElementById("orderPrint");
   if (printContents) {
     const printWindow = window.open("", "", "height=600,width=800");
@@ -720,7 +735,7 @@ const handlePrintTicket = async () => {
       "Elemento #orderPrint no encontrado para impresión tipo ticket. Imprimiendo toda la página."
     );
     window.print();
-  }
+  }*/
 };
 
 // Función para cancelar después de ver el ticket

--- a/resources/js/pages/tpv/orderUser.vue
+++ b/resources/js/pages/tpv/orderUser.vue
@@ -112,10 +112,13 @@ const currentUser = computed(() => authStore.user);
 
 const hasOpenOrder = ref(false);
 const openOrderData = ref(null);
+const orderData = ref(null);
 
 const reservedOrderData = ref(null);
 
 const orderItems = ref([]);
+const itemsToPrint = ref([]);
+const TotalToPrint = ref(0);
 
 const showBuysModal = ref(false);
 
@@ -2017,7 +2020,6 @@ const handleBuysCompletion = async (
     if (selectedDiscountType.value === "Recipe" && prescriptionFile.value) {
       formData.append("prescription_image", prescriptionFile.value);
     }
-
     const response = await axios.post(
       `/tpv/orders/${orderId}/complete`,
       formData,
@@ -2039,16 +2041,16 @@ const handleBuysCompletion = async (
       speSurchargeAmount.value = specialTaxAmount.value;
       clientIdentification.value = "";
       await fetchProducts();
-      showBuysModal.value = false;
-      isPrinting.value = true;
+     // showBuysModal.value = false;
+    //  isPrinting.value = true;
       recipeDiscountForPrint.value = totalRecipeDiscountAmount.value;
       doctorDiscountForPrint.value = totalDoctorDiscountAmount.value;
       companyDiscountForPrint.value = totalCompanyDiscountAmount.value;
       discountTypeForPrint.value = selectedDiscountType.value;
 
-      await nextTick();
-      const printContents = document.getElementById("orderPrint");
-      if (printContents) {
+     // await nextTick();
+    //  const printContents = document.getElementById("orderPrint");
+     /* if (printContents) {
         const printWindow = window.open("", "", "height=600,width=800");
         printWindow.document.write(
           "<html><head><title>Farmacia Barrio Sucre</title>"
@@ -2088,7 +2090,11 @@ const handleBuysCompletion = async (
           "Elemento #orderPrint no encontrado para impresión tipo ticket. Imprimiendo toda la página."
         );
         window.print();
-      }
+      }*/
+
+      const orderCompletada = response.data.data.orderCompletada;
+      orderData.value = orderCompletada;
+     itemsToPrint.value = JSON.parse(JSON.stringify(orderItems.value))
       if (response.data.data.order) {
         hasOpenOrder.value = true;
         openOrderData.value = response.data.data.order;
@@ -2109,13 +2115,68 @@ const handleBuysCompletion = async (
   } catch (error) {
     console.error("Error al finalizar la compra:", error);
     toast.error("Hubo un problema al procesar su compra.");
-    isPrinting.value = false;
+   // isPrinting.value = false;
   } finally {
-    setTimeout(() => {
+   /* setTimeout(() => {
       isFinishingOrder.value = false;
       resetFormSelectors();
       isPrinting.value = false;
+    }, 500);*/
+  }
+};
+
+const printTickeCompletion = async () => {
+  if (!orderData.value) {
+    console.error("No hay datos de orden para imprimir");
+    return;
+  }
+
+  console.log(orderData.value);
+  TotalToPrint.value = parseFloat(orderData.value.total_amount);
+  const speAmount = orderData.value.spe_surcharge_amount || 0;
+  speSurchargeAmount.value = speAmount.toString();
+  paymentsForPrint.value = paymentsForPrint.value.filter(p => {
+    const name = (p.method || "").toString().toUpperCase();
+    return name !== 'N/A' && name !== '' && name !== 'UNDEFINED';
+  });
+
+  isPrinting.value = true;
+  await nextTick();
+  await new Promise(resolve => setTimeout(resolve, 600)); 
+  const printContents = document.getElementById("orderPrint");
+
+  if (printContents && printContents.innerHTML.trim() !== "") {
+    const printWindow = window.open("", "", "height=600,width=800");
+    printWindow.document.write("<html><head><title>Farmacia Barrio Sucre</title>");
+
+    // Copiar estilos (el bloque try/catch que ya tienes)
+    Array.from(document.styleSheets).forEach(sheet => {
+      try {
+        if (sheet.cssRules) {
+          const css = Array.from(sheet.cssRules).map(r => r.cssText).join("");
+          printWindow.document.write(`<style>${css}</style>`);
+        } else if (sheet.href) {
+          printWindow.document.write(`<link rel="stylesheet" href="${sheet.href}">`);
+        }
+      } catch (e) {
+        if (sheet.href) printWindow.document.write(`<link rel="stylesheet" href="${sheet.href}">`);
+      }
+    });
+
+    printWindow.document.write("</head><body>");
+    printWindow.document.write(printContents.innerHTML);
+    printWindow.document.write("</body></html>");
+    
+    printWindow.document.close();
+    setTimeout(() => {
+      printWindow.focus();
+      printWindow.print();
+      printWindow.close();
+      isPrinting.value = false;
     }, 500);
+  } else {
+    alert("Error: El ticket está vacío. Intente de nuevo.");
+    isPrinting.value = false;
   }
 };
 
@@ -2485,25 +2546,40 @@ const handleAddPackToOrder = async ({ pack, quantity }) => {
 */
 const itemsForTicket = computed(() => {
   const globalDiscount = currentGlobalDiscountDetails.value;
-  return orderItems.value.map(item => {
+  
+  // Si no hay nada que imprimir, retornamos array vacío
+  if (!itemsToPrint.value || itemsToPrint.value.length === 0) return [];
+
+  return itemsToPrint.value.map(item => {
+    // Si el item ya tiene descuento por vencimiento, lo dejamos igual
     if (item.discount_type === 'expiration') {
       return { ...item };
     }
+
+    // Normalizamos la cantidad (Laravel usa 'quantity', el carrito local 'selectedQuantity')
+    const qty = item.selectedQuantity || item.quantity || 1;
+    
     if (globalDiscount && globalDiscount.percentage > 0) {
       const factor = 1 - (globalDiscount.percentage / 100);
       
       return {
         ...item,
-        price: (item.price_before_discount * factor) * item.selectedQuantity,
-        price_bs: (item.original_price_bs * factor) * item.selectedQuantity,
-        price_cop: (item.original_price_cop * factor) * item.selectedQuantity,
-        price_before_discount: item.price_before_discount * item.selectedQuantity
+        // Usamos el precio base y lo multiplicamos por el factor y la cantidad
+        price: (item.price_before_discount * factor) * qty,
+        price_bs: (item.original_price_bs * factor) * qty,
+        price_cop: (item.original_price_cop * factor) * qty,
+        price_before_discount: item.price_before_discount * qty,
+        selectedQuantity: qty // Aseguramos que el ticket vea la cantidad
       };
     }
-    return { ...item };
+
+    // Si no hay descuento global, devolvemos el item con su cantidad normalizada
+    return { 
+      ...item, 
+      selectedQuantity: qty 
+    };
   });
 });
-
 const handleExternalSort = async (sortData) => {
   sortBy.value = sortData.key;
   orderBy.value = sortData.order;
@@ -2646,17 +2722,18 @@ const handleExternalSort = async (sortData) => {
       :active-company-offers="activeCompanyOffers"
       :global-discount="currentGlobalDiscountDetails"
       :is-special-taxpayer="isSpecialTaxpayer"
+      @printTicke-completed="printTickeCompletion"
     />
 
-    <div
-      id="orderPrint"
-      :class="{ 'd-none': !isPrinting, 'print-container': true }"
-    >
+   <div
+  id="orderPrint"
+  :style="isPrinting ? 'position: fixed; left: 0; top: 0; z-index: 9999; background: white; width: 80mm;' : 'position: absolute; left: -9999px;'"
+>
       <OrderTicket
-        v-if="isPrinting && openOrderData"
-        :order-data="openOrderData"
+        v-if="orderData"
+        :order-data="orderData"
         :order-products="itemsForTicket"
-        :total-amount="totalOrderAmountWithspecialTaxAmount"
+        :total-amount="TotalToPrint"
         :selected-currency="selectedDisplayCurrency"
         :payments="paymentsForPrint"
         :change-amount="changeAmountForPrint"


### PR DESCRIPTION
### **User description**
…de ticke.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactor purchase completion flow to emit event at progress stage completion

- Move ticket printing logic to separate async function with improved styling

- Store completed order data for ticket display instead of using open order data

- Filter invalid payment methods and normalize item quantities for ticket rendering

- Return completed order data in API response for frontend ticket generation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Purchase Progress"] -->|"Emit at stage completion"| B["purchase-completed event"]
  B --> C["Store orderData"]
  C --> D["printTickeCompletion function"]
  D --> E["Generate ticket with filtered payments"]
  E --> F["Print window with styled output"]
  G["API complete endpoint"] -->|"Return orderCompletada"| H["Frontend receives completed order"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BuysModal.vue</strong><dd><code>Move purchase completion event to progress completion</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/js/components/dialogs/BuysModal.vue

<ul><li>Emit <code>purchase-completed</code> event when progress reaches 100% instead of <br>only at final stage<br> <li> Comment out original print logic in <code>handlePrintTicket</code> function<br> <li> Replace <code>nextTick</code> with <code>emit("printTicke-completed")</code> to delegate <br>printing to parent<br> <li> Simplify ticket printing by removing inline print window logic</ul>


</details>


  </td>
  <td><a href="https://github.com/Alexiva1995/erp_farmacias/pull/503/files#diff-c20bdcd0bc0a6ecdf5d99adb073acf5b8ae6afcf9f1b921dbeda67a71e955e9a">+19/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>orderUser.vue</strong><dd><code>Implement deferred ticket printing with order data storage</code></dd></summary>
<hr>

resources/js/pages/tpv/orderUser.vue

<ul><li>Add <code>orderData</code>, <code>itemsToPrint</code>, and <code>TotalToPrint</code> reactive variables to <br>store completed order details<br> <li> Create new <code>printTickeCompletion</code> async function to handle ticket <br>printing with improved styling and payment filtering<br> <li> Update <code>itemsForTicket</code> computed property to use <code>itemsToPrint</code> instead of <br><code>orderItems</code> and normalize quantities<br> <li> Modify <code>handleBuysCompletion</code> to store completed order data and items <br>instead of immediately printing<br> <li> Update <code>OrderTicket</code> component binding to use <code>orderData</code> and <code>TotalToPrint</code> <br>instead of <code>openOrderData</code><br> <li> Change <code>orderPrint</code> div styling to use fixed positioning when printing <br>for better layout control<br> <li> Add listener for <code>@printTicke-completed</code> event from BuysModal component</ul>


</details>


  </td>
  <td><a href="https://github.com/Alexiva1995/erp_farmacias/pull/503/files#diff-acc2344a2e12a15cb97450bf16705956f17bdd61b25f4958a732ddac3191c41b">+100/-23</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OrderActionService.php</strong><dd><code>Return completed order data in API response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/Services/Order/OrderActionService.php

<ul><li>Load order relationships (seller, client, details.product) before <br>returning from complete method<br> <li> Return completed order data in response array as <code>orderCompletada</code> key <br>alongside pending order<br> <li> Add commented debug statement for lot quantity validation</ul>


</details>


  </td>
  <td><a href="https://github.com/Alexiva1995/erp_farmacias/pull/503/files#diff-824a5584fb809c11a961f1ca7584b0c46f2e3781b9d043a369a35210b7250dff">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

