### PR TITLE
fix: mostrar todos los registros al paginar

### DIFF
--- a/app/Http/Controllers/Api/InventoryCycleController.php
+++ b/app/Http/Controllers/Api/InventoryCycleController.php
@@ -55,7 +55,7 @@ class InventoryCycleController extends Controller
     public function storeProductCount(Request $request, $productId)
     {
         $allowWithoutBarcode = $request->boolean('allow_without_barcode');
-        
+
         $validationRules = [
             'counted_quantity' => 'required|numeric|min:0',
             'system_quantity' => 'required|numeric|min:0',
@@ -230,7 +230,7 @@ class InventoryCycleController extends Controller
     {
         try {
             $activeCycleId = \App\Models\InventoryCycle::where('status', 'active')->value('id');
-            
+
             if (!$activeCycleId) {
                 return response()->json([]);
             }
@@ -242,6 +242,9 @@ class InventoryCycleController extends Controller
                 ->join('product_counts', 'users.id', '=', 'product_counts.user_id')
                 ->leftJoin('employees', 'users.id', '=', 'employees.user_id')
                 ->where('product_counts.cycle_id', $activeCycleId)
+                ->when(Auth::user()->role !== 'admin', function ($query) {
+                    $query->where('users.id', '!=', Auth::id());
+                })
                 ->union(
                     \App\Models\User::query()
                         ->select('users.id', 'users.username', 'users.email')
@@ -288,7 +291,7 @@ class InventoryCycleController extends Controller
     public function storeInvoiceCount(Request $request, $productId)
     {
         $allowWithoutBarcode = $request->boolean('allow_without_barcode');
-        
+
         $validationRules = [
             'counted_quantity' => 'required|numeric|min:0',
             'system_quantity' => 'required|numeric|min:0',
@@ -305,7 +308,7 @@ class InventoryCycleController extends Controller
         try {
             $data = $request->all();
             $data['allow_without_barcode'] = $allowWithoutBarcode;
-            
+
             $result = $this->inventoryCycleActionService->createInvoiceCount($productId, $data);
 
             if ($result['success']) {
@@ -393,13 +396,13 @@ class InventoryCycleController extends Controller
         // Calcular totales sobre TODOS los registros (no solo la página actual)
         $totalsQuery = $this->inventoryCycleQueryService->getCashCloseItemsQuery($request);
         $allItems = $totalsQuery->get();
-        
+
         $totals = [
             'surplus' => 0,
             'shortage' => 0,
             'netTotal' => 0
         ];
-        
+
         foreach ($allItems as $item) {
             $amount = ($item->product_sale_price ?? 0) * $item->discrepancy;
             if ($amount > 0) {
@@ -408,7 +411,7 @@ class InventoryCycleController extends Controller
                 $totals['shortage'] += abs($amount);
             }
         }
-        
+
         $totals['netTotal'] = $totals['surplus'] - $totals['shortage'];
 
         return response()->json([
@@ -472,7 +475,7 @@ class InventoryCycleController extends Controller
         }
     }
 
-     public function getSaleDetailsToCount(Request $request)
+    public function getSaleDetailsToCount(Request $request)
     {
         $query = $this->inventoryCycleQueryService->getSalesDetailsToCountQuery($request);
         $perPage = $request->input('itemsPerPage', 10);
@@ -486,10 +489,10 @@ class InventoryCycleController extends Controller
         return response()->json(['data' => $paginatedResult->items(), 'total' => $paginatedResult->total()]);
     }
 
-     public function storeSaleCount(Request $request, $productId)
+    public function storeSaleCount(Request $request, $productId)
     {
         $allowWithoutBarcode = $request->boolean('allow_without_barcode');
-        
+
         $validationRules = [
             'counted_quantity' => 'required|numeric|min:0',
             'system_quantity' => 'required|numeric|min:0',
@@ -506,7 +509,7 @@ class InventoryCycleController extends Controller
         try {
             $data = $request->all();
             $data['allow_without_barcode'] = $allowWithoutBarcode;
-            
+
             $result = $this->inventoryCycleActionService->createSaleCount($productId, $data);
 
             if ($result['success']) {
@@ -540,7 +543,7 @@ class InventoryCycleController extends Controller
             ], 500);
         }
     }
-    
+
     public function getSaleCount(Request $request)
     {
         $query = $this->inventoryCycleQueryService->getSaleCountFilteredQuery($request);
@@ -551,7 +554,7 @@ class InventoryCycleController extends Controller
     }
 
 
-     public function processSaleCountAction(Request $request, $countId)
+    public function processSaleCountAction(Request $request, $countId)
     {
         $request->validate([
             'action' => 'required|in:approve,reject',

--- a/app/Services/Groups/GroupQueryService.php
+++ b/app/Services/Groups/GroupQueryService.php
@@ -79,6 +79,12 @@ class GroupQueryService
         $this->applySorting($query, $request);
 
         $perPage = $request->input('itemsPerPage', 10);
+
+        if ($perPage == -1) {
+            $perPage = 99999;
+            return $query->paginate($perPage);
+        }
+
         return $query->paginate($perPage);
     }
 

--- a/app/Services/InventoryCycle/InventoryCycleQueryService.php
+++ b/app/Services/InventoryCycle/InventoryCycleQueryService.php
@@ -69,7 +69,7 @@ class InventoryCycleQueryService
             $model = $query->getModel();
             $tableName = $model->getTable();
             $discrepancyColumn = "{$tableName}.discrepancy";
-            
+
             switch ($filters['discrepancyFilter']) {
                 case 'with_discrepancy':
                     $query->where($discrepancyColumn, '!=', 0);
@@ -255,6 +255,13 @@ class InventoryCycleQueryService
         }
     }
 
+    private function applyNotAuthUserFilterToCount(Builder $query): Builder
+    {
+        $query->where('user_id', '!=', auth()->id());
+
+        return $query;
+    }
+
     public function getFilteredQuery(Request $request): Builder
     {
         $query = $this->getBaseQuery();
@@ -271,14 +278,15 @@ class InventoryCycleQueryService
             'is_history' => $isHistoryView,
         ];
 
-        
+
         if ($isHistoryView || $request->cycleId) {
             $filters['status'] = ['approved', 'rejected', 'pending'];
         } else {
-            $filters['status'] =  'pending';
+            $filters['status'] = 'pending';
         }
-      
+
         $query = $this->applyFiltersToCount($query, $filters);
+        $query = $this->applyNotAuthUserFilterToCount($query);
         $query = $this->applySortingToCount($query, $request->input('sortBy'), $request->input('orderBy', 'desc'));
 
         return $query;
@@ -419,6 +427,7 @@ class InventoryCycleQueryService
         ];
 
         $query = $this->applyFiltersToCount($query, $filters);
+        $query = $this->applyNotAuthUserFilterToCount($query);
         $query = $this->applySortingToCount($query, $request->input('sortBy'), $request->input('orderBy', 'desc'));
 
         return $query;
@@ -627,7 +636,7 @@ class InventoryCycleQueryService
     }
 
 
-      public function getSalesDetailsToCountQuery(Request $request): Builder
+    public function getSalesDetailsToCountQuery(Request $request): Builder
     {
         $query = Product::query()->with(['lots', 'laboratory', 'origin']);
 
@@ -636,8 +645,8 @@ class InventoryCycleQueryService
                 ->where('order_date', '>=', '2026-01-25');
             $subQuery->whereHas('cashClosing', function ($cashQuery) {
                 $cashQuery->where('status', 'closed')
-                    ->where('closing_date', '>=', '2026-01-25'); 
-                $cashQuery->has('dailyClosure'); 
+                    ->where('closing_date', '>=', '2026-01-25');
+                $cashQuery->has('dailyClosure');
             });
         });
 
@@ -662,7 +671,7 @@ class InventoryCycleQueryService
     }
 
 
-        private function getSaleCountBaseQuery(): Builder
+    private function getSaleCountBaseQuery(): Builder
     {
         return SaleCount::query()->select('sales_counts.*')->with([
             'product' => function ($query) {
@@ -674,7 +683,7 @@ class InventoryCycleQueryService
         ]);
     }
 
-     public function getSaleCountFilteredQuery(Request $request): Builder
+    public function getSaleCountFilteredQuery(Request $request): Builder
     {
         $query = $this->getSaleCountBaseQuery();
 
@@ -694,6 +703,7 @@ class InventoryCycleQueryService
         ];
 
         $query = $this->applyFiltersToCount($query, $filters);
+        $query = $this->applyNotAuthUserFilterToCount($query);
         $query = $this->applySortingToCount($query, $request->input('sortBy'), $request->input('orderBy', 'desc'));
 
         return $query;

--- a/resources/js/navigation/vertical/cyclicInventory.js
+++ b/resources/js/navigation/vertical/cyclicInventory.js
@@ -1,0 +1,38 @@
+export default [
+  {
+    title: "Inventario Ciclicos",
+    icon: {
+      is: "font-awesome-icon",
+      props: {
+        icon: ["fas", "boxes-stacked"],
+        size: "sm",
+      },
+    },
+    children: [
+      {
+        title: "Historial",
+        to: "cyclics-history",
+        action: "manage",
+        subject: "cyclic-history",
+      },
+      {
+        title: "Cierre de Inventario",
+        to: "cyclics-closing",
+        action: "manage",
+        subject: "closing-cyclics",
+      },
+      {
+        title: "Pendientes",
+        to: "cyclics-cyclic",
+        action: "manage",
+        subject: "pending-cyclics",
+      },
+      {
+        title: "Inventarios Users",
+        to: "cyclics-users",
+        action: "manage",
+        subject: "user",
+      },
+    ],
+  },
+];

--- a/resources/js/navigation/vertical/index.js
+++ b/resources/js/navigation/vertical/index.js
@@ -1,5 +1,7 @@
 import businessIntelligence from './businessIntelligence'
+import configuration from './configuration'
 import crm from './crm'
+import cyclicInventory from './cyclicInventory'
 import finances from './finances'
 import fiscal from './fiscal'
 import inventory from './inventory'
@@ -8,11 +10,6 @@ import productivity from './productivity'
 import rrhh from './rrhh'
 import suppliers from './suppliers'
 import tpv from './tpv'
-import configuration from './configuration'
 
-
-
-
-
-export default [...inventory, ...tpv, ...crm, ...rrhh, ...fiscal, ...finances,...suppliers, ...invoice, ...productivity, ...businessIntelligence, ...configuration]
+export default [...inventory, ...cyclicInventory, ...tpv, ...crm, ...rrhh, ...fiscal, ...finances,...suppliers, ...invoice, ...productivity, ...businessIntelligence, ...configuration]
 

--- a/resources/js/navigation/vertical/inventory.js
+++ b/resources/js/navigation/vertical/inventory.js
@@ -51,42 +51,6 @@ export default [
         action: 'manage',
         subject: 'admin',
       },
-       {
-        title: 'Inventario Ciclicos',
-        icon: {
-        is: 'font-awesome-icon', 
-        props: {
-          icon: ['fas', 'boxes-stacked'],
-          size: 'sm',
-        },
-      },
-        children: [
-                  {
-          title: 'Historial',
-          to: 'cyclics-history',
-          action: 'manage',
-          subject: 'cyclic-history',
-        },
-         {
-          title: 'Cierre de Inventario',
-          to: 'cyclics-closing',
-          action: 'manage',
-          subject: 'closing-cyclics',
-        },
-        {
-          title: 'Pendientes',
-          to: 'cyclics-cyclic',
-          action: 'manage',
-          subject: 'pending-cyclics',
-        },
-        {
-          title: 'Inventarios Users',
-          to: 'cyclics-users',
-          action: 'manage',
-          subject: 'user',
-        }
-        ]
-      },
       {
           title: 'Inventario  Ciclicos',
           to: 'cyclics-users',


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Handle special case when itemsPerPage is -1 to show all records

- Return paginated results with large limit instead of default pagination


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Request with itemsPerPage"] --> B{"itemsPerPage == -1?"}
  B -->|Yes| C["Set perPage to 99999"]
  B -->|No| D["Use requested perPage value"]
  C --> E["Paginate with large limit"]
  D --> E
  E --> F["Return LengthAwarePaginator"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GroupQueryService.php</strong><dd><code>Add special case handling for show-all pagination</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/Services/Groups/GroupQueryService.php

<ul><li>Added special handling for itemsPerPage value of -1 to display all <br>records<br> <li> When -1 is passed, sets perPage to 99999 to bypass pagination limits<br> <li> Maintains existing pagination behavior for all other itemsPerPage <br>values</ul>


</details>


  </td>
  <td><a href="https://github.com/Alexiva1995/erp_farmacias/pull/562/files#diff-36b58d726a0ca9b7a72df542457dcb561ea5802e142b1c56186113f4a0e88cf5">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

