### PR TITLE
fix(invoice): unificar etiqueta exp_date a Vencimiento

### DIFF
--- a/resources/js/components/InvoiceTable.vue
+++ b/resources/js/components/InvoiceTable.vue
@@ -38,6 +38,7 @@ const headers = computed(() => {
     { title: "N° Factura", key: "invoice_number", sortable: true },
     { title: "N° Control", key: "control_number", sortable: true },
     { title: "Emisión", key: "created_invoice_date", sortable: true },
+    { title: "Vencimiento", key: "exp_date", sortable: true },
   ];
 
   if (props.actionsMode === "location") {


### PR DESCRIPTION
Se cambió 'Exp. Documento' por 'Vencimiento' en invoiceDetails.vue y se añadió la columna 'Vencimiento' en InvoiceTable.vue para mayor consistencia y visibilidad del vencimiento de facturas.