### PR TITLE
Mejora

### DIFF
--- a/app/Http/Controllers/Api/SuppliersIaOrderAssistantController.php
+++ b/app/Http/Controllers/Api/SuppliersIaOrderAssistantController.php
@@ -113,6 +113,10 @@ class SuppliersIaOrderAssistantController extends Controller
             $filtros["stock"] = $request->stock;
         }
 
+        if ($request->filled("hasStock") && $request->hasStock !== "all") {
+            $filtros["hasStock"] = $request->hasStock === "with" || $request->hasStock === "true" || $request->hasStock === true;
+        }
+
         if ($request->filled("laboratoryId")) {
             $filtros["laboratoryId"] = $request->laboratoryId;
         }

--- a/app/Http/Controllers/PurchaseOrderController.php
+++ b/app/Http/Controllers/PurchaseOrderController.php
@@ -88,4 +88,9 @@ class PurchaseOrderController extends Controller
         $repo->rejectPendingDetails($autoOrder);
         return response()->json(['status' => 'ok', 'message' => 'Productos pendientes marcados como rechazados.']);
     }
+    public function revertToSent(AutoOrder $autoOrder)
+    {
+        $repo = new \App\Repository\AutoOrdersRepository();
+        return response()->json(['success' => $repo->revertToSent($autoOrder)]);
+    }
 }

--- a/app/Repository/AutoOrdersRepository.php
+++ b/app/Repository/AutoOrdersRepository.php
@@ -61,6 +61,9 @@ class AutoOrdersRepository
             $query->whereDate("auto_orders.order_date", "<=", $endDate);
         }
 
+        // Ordenar siempre desde la más reciente (ID más alto) a la más antigua
+        $query->orderByDesc("auto_orders.id");
+
         return $query->paginate($perPage);
     }
 
@@ -323,5 +326,23 @@ class AutoOrdersRepository
         ]);
         
         $this->checkAndCompleteOrder($autoOrder);
+    }
+
+    public function revertToSent(AutoOrder $autoOrder): bool
+    {
+        return DB::transaction(function () use ($autoOrder) {
+            // Revertir estado de la orden a ENVIADA (1)
+            $autoOrder->update([
+                'status' => AutoOrderStatus::SENT
+            ]);
+
+            // Revertir todos sus detalles a PENDIENTES (status = 0, received = null)
+            $autoOrder->details()->update([
+                'status' => \App\AutoOrderDetailStatus::PENDING->value,
+                'received' => null
+            ]);
+
+            return true;
+        });
     }
 }

--- a/app/Services/Expirations/ExpirationQueryService.php
+++ b/app/Services/Expirations/ExpirationQueryService.php
@@ -141,7 +141,7 @@ class ExpirationQueryService
 
         return InventoryMovement::with([
             'product' => function ($q) {
-                $q->withTrashed()->with('laboratory');
+                $q->withTrashed()->withoutGlobalScope('not_deleted')->with('laboratory');
             },
             'productLot',
             'user.employee'

--- a/components.d.ts
+++ b/components.d.ts
@@ -368,6 +368,5 @@ declare module 'vue' {
     UserInfoEditDialog: typeof import('./resources/js/components/dialogs/UserInfoEditDialog.vue')['default']
     UserUpgradePlanDialog: typeof import('./resources/js/components/dialogs/UserUpgradePlanDialog.vue')['default']
     VerifyCountModal: typeof import('./resources/js/components/dialogs/VerifyCountModal.vue')['default']
-    VueApexCharts: typeof import('vue3-apexcharts')['default']
   }
 }

--- a/resources/js/components/PurchaseOrdersTable.vue
+++ b/resources/js/components/PurchaseOrdersTable.vue
@@ -14,6 +14,7 @@ const emit = defineEmits([
   "update:options",
   "manage",
   "delete-purchaseOrder",
+  "revert",
 ]);
 
 const { mobile } = useDisplay();
@@ -161,6 +162,20 @@ const formatTime = (dateString) => {
       <!-- Acciones -->
       <template #item.actions="{ item }">
         <div class="d-flex align-center justify-center gap-2">
+          <!-- Botón Devolver a Enviada (sólo si está COMPLETADA) -->
+          <VBtn
+            v-if="item.status === 2"
+            icon
+            size="32"
+            variant="tonal"
+            color="warning"
+            class="rounded-circle shadow-sm"
+            @click="emit('revert', item)"
+          >
+            <VIcon icon="tabler-arrow-back-up" size="18" />
+            <VTooltip activator="parent" location="top">Devolver a Enviada</VTooltip>
+          </VBtn>
+
           <VBtn
             icon
             size="32"
@@ -259,6 +274,19 @@ const formatTime = (dateString) => {
             </VRow>
 
             <div class="d-flex align-center gap-2 mt-4">
+              <!-- Botón Devolver a Enviada en móvil -->
+              <VBtn
+                v-if="item.status === 2"
+                icon
+                variant="tonal"
+                color="warning"
+                class="rounded-lg"
+                size="32"
+                @click="emit('revert', item)"
+              >
+                <VIcon icon="tabler-arrow-back-up" size="18" />
+              </VBtn>
+
               <VBtn
                 color="primary"
                 variant="tonal"

--- a/resources/js/components/SupplierIaOrderAssistantFilter.vue
+++ b/resources/js/components/SupplierIaOrderAssistantFilter.vue
@@ -24,6 +24,7 @@ const props = defineProps({
   showGraphs:         { type: Boolean, default: false },
   selectedSupplier:   { type: [Number, String, Object, null], default: null },
   suppliers:          { type: Array,   default: () => [] },
+  hasStock:           { type: String,  default: "all" },
 });
 
 const emit = defineEmits([
@@ -33,6 +34,7 @@ const emit = defineEmits([
   "update:tipo_de_filtracion",
   "update:lapso_de_tiempo",
   "update:stock",
+  "update:hasStock",
   "update:selectedLaboratory",
   "update:selectedGroup",
   "update:isColombian",
@@ -78,8 +80,14 @@ const stockOpciones = [
   { title: "Todos",  value: "all"    },
 ];
 
+const hasStockOpciones = [
+  { title: "Todos",       value: "all"     },
+  { title: "Con Stock",   value: "with"    },
+  { title: "Sin Stock",   value: "without" },
+];
+
 const hasAdvancedFilters = computed(() => (
-  !!(props.selectedGroup?.length || props.isColombian || props.isNovaventa || props.tipo_de_filtracion !== 'combinado' || props.stock !== 'fallas' || props.selectedSupplier)
+  !!(props.selectedGroup?.length || props.isColombian || props.isNovaventa || props.tipo_de_filtracion !== 'combinado' || props.stock !== 'fallas' || props.selectedSupplier || props.hasStock !== 'all')
 ));
 </script>
 
@@ -171,7 +179,7 @@ const hasAdvancedFilters = computed(() => (
         <VAutocomplete
           :model-value="props.selectedSupplier"
           :items="props.suppliers"
-          placeholder="Proveedor Destino"
+          label="Proveedor Destino"
           item-title="name"
           item-value="id"
           clearable
@@ -187,7 +195,7 @@ const hasAdvancedFilters = computed(() => (
         <VAutocomplete
           :model-value="props.selectedLaboratory"
           :items="props.laboratories"
-          :placeholder="isRestaurant ? 'Marcas' : 'Laboratorios'"
+          :label="isRestaurant ? 'Marcas' : 'Laboratorios'"
           item-title="name"
           item-value="id"
           clearable
@@ -206,7 +214,7 @@ const hasAdvancedFilters = computed(() => (
         <VAutocomplete
           :model-value="props.selectedGroup"
           :items="props.groups"
-          placeholder="Grupos"
+          label="Grupos"
           item-title="name"
           item-value="id"
           clearable
@@ -225,7 +233,7 @@ const hasAdvancedFilters = computed(() => (
         <VSelect
           :model-value="props.lapso_de_tiempo"
           :items="lapsoDeTiempoOpciones"
-          placeholder="Periodo"
+          label="Periodo"
           density="compact"
           hide-details
           prepend-inner-icon="tabler-calendar-time"
@@ -238,7 +246,7 @@ const hasAdvancedFilters = computed(() => (
         <VSelect
           :model-value="props.tipo_de_filtracion"
           :items="tipoFiltracionOpcion"
-          placeholder="Cálculo"
+          label="Cálculo"
           density="compact"
           hide-details
           prepend-inner-icon="tabler-math-function"
@@ -251,7 +259,7 @@ const hasAdvancedFilters = computed(() => (
         <VSelect
           :model-value="props.tipo_de_vista"
           :items="tipoDeVistaOpcion"
-          placeholder="Vista"
+          label="Vista"
           density="compact"
           hide-details
           prepend-inner-icon="tabler-layout-grid"
@@ -264,7 +272,7 @@ const hasAdvancedFilters = computed(() => (
         <VSelect
           :model-value="props.selectConDescuento"
           :items="precio"
-          placeholder="Precios"
+          label="Precios"
           density="compact"
           hide-details
           prepend-inner-icon="tabler-currency-dollar"
@@ -277,11 +285,24 @@ const hasAdvancedFilters = computed(() => (
         <VSelect
           :model-value="props.stock"
           :items="stockOpciones"
-          placeholder="Stock"
+          label="Análisis Stock"
           density="compact"
           hide-details
           prepend-inner-icon="tabler-box"
           @update:model-value="emit('update:stock', $event)"
+        />
+      </VCol>
+
+      <!-- Disponibilidad Inventario -->
+      <VCol cols="12" sm="6" md="2">
+        <VSelect
+          :model-value="props.hasStock"
+          :items="hasStockOpciones"
+          label="Disponibilidad"
+          density="compact"
+          hide-details
+          prepend-inner-icon="tabler-package"
+          @update:model-value="emit('update:hasStock', $event)"
         />
       </VCol>
 

--- a/resources/js/components/dialogs/PurchaseOrderManagementDialog.vue
+++ b/resources/js/components/dialogs/PurchaseOrderManagementDialog.vue
@@ -18,6 +18,7 @@ const { mobile } = useDisplay();
 const loading = ref(false);
 const saving = ref(false);
 const sending = ref(false);
+const reverting = ref(false);
 const details = ref([]);
 const page = ref(1);
 const itemsPerPage = ref(10);
@@ -43,15 +44,7 @@ watch(searchQuery, () => {
   }, 300);
 });
 
-const closeDialog = async (shouldReject = true) => {
-  if (shouldReject && props.purchaseOrder?.id && props.purchaseOrder.status === 1) {
-    try {
-      await axios.post(`/suppliers/purchase-orders/${props.purchaseOrder.id}/reject-pending`);
-      emit("refresh");
-    } catch (error) {
-      console.error("Error al rechazar productos pendientes:", error);
-    }
-  }
+const closeDialog = () => {
   emit("update:modelValue", false);
   page.value = 1;
   searchQuery.value = "";
@@ -166,6 +159,21 @@ const handleConfirmSent = async () => {
     toast.error("Error al procesar la solicitud.");
   } finally {
     sending.value = false;
+  }
+};
+
+// Revertir el estado de la orden de compra a Enviada
+const handleRevertToSent = async () => {
+  reverting.value = true;
+  try {
+    await axios.post(`/suppliers/purchase-orders/${props.purchaseOrder.id}/revert-to-sent`);
+    toast.success("Orden devuelta a estado enviada correctamente.");
+    emit("refresh");
+    closeDialog(false);
+  } catch (error) {
+    toast.error("Error al devolver la orden a enviada.");
+  } finally {
+    reverting.value = false;
   }
 };
 

--- a/resources/js/pages/suppliers/purchase-orders/list.vue
+++ b/resources/js/pages/suppliers/purchase-orders/list.vue
@@ -128,6 +128,20 @@ const handleDeleteOrder = async (id) => {
     } catch (error) {
       toast.error("Error al eliminar la orden.");
     }
+const handleRevertOrder = async (order) => {
+  if (
+    confirm(
+      `¿Estás seguro de devolver la orden de compra #${order.id} al estado 'Enviada'? Los productos marcados como recibidos volverán a estar pendientes.`,
+    )
+  ) {
+    try {
+      await axios.post(`/suppliers/purchase-orders/${order.id}/revert-to-sent`);
+      toast.success("Orden devuelta a estado 'Enviada' correctamente.");
+      fetchPurchaseOrders();
+      fetchStats();
+    } catch (error) {
+      toast.error("Error al devolver la orden a enviada.");
+    }
   }
 };
 
@@ -313,6 +327,7 @@ const handleClearFilters = () => {
         @update:options="updateTableOptions"
         @manage="handleManage"
         @delete-purchaseOrder="handleDeleteOrder"
+        @revert="handleRevertOrder"
         @refresh="
           fetchPurchaseOrders();
           fetchStats();

--- a/resources/js/pages/suppliers/purchase-orders/list.vue
+++ b/resources/js/pages/suppliers/purchase-orders/list.vue
@@ -128,6 +128,9 @@ const handleDeleteOrder = async (id) => {
     } catch (error) {
       toast.error("Error al eliminar la orden.");
     }
+  }
+};
+
 const handleRevertOrder = async (order) => {
   if (
     confirm(

--- a/resources/js/pages/suppliers/supplieriaorderassistant.vue
+++ b/resources/js/pages/suppliers/supplieriaorderassistant.vue
@@ -31,6 +31,7 @@ const tipo_de_vista = ref(false);
 const tipo_de_filtracion = ref("combinado");
 const lapso_de_tiempo = ref("1 month");
 const stock = ref("fallas");
+const hasStock = ref("all");
 const con_descuento = ref(false);
 const isColombian = ref(false);
 const isNovaventa = ref(false);
@@ -48,6 +49,7 @@ const handleClearFilters = () => {
   tipo_de_filtracion.value = "combinado";
   lapso_de_tiempo.value = "1 month";
   stock.value = "fallas";
+  hasStock.value = "all";
   isColombian.value = false;
   isNovaventa.value = false;
   selectedLaboratory.value = [];
@@ -91,6 +93,7 @@ async function consultarProductosConPaginacion() {
     tipo_filtracion: tipo_de_filtracion.value,
     lapso_de_tiempo: lapso_de_tiempo.value,
     stock: stock.value,
+    hasStock: hasStock.value,
     isColombian: isColombian.value,
     isNovaventa: isNovaventa.value,
     q: searchQuery.value,
@@ -231,6 +234,7 @@ watch(
     tipo_de_filtracion,
     lapso_de_tiempo,
     stock,
+    hasStock,
     isColombian,
     isNovaventa,
     searchQuery,
@@ -457,6 +461,7 @@ onMounted(async () => {
         v-model:tipo_de_filtracion="tipo_de_filtracion"
         v-model:lapso_de_tiempo="lapso_de_tiempo"
         v-model:stock="stock"
+        v-model:hasStock="hasStock"
         v-model:searchQuery="searchQuery"
         v-model:showIgnored="showIgnored"
         v-model:showGraphs="showGraphs"

--- a/routes/api.php
+++ b/routes/api.php
@@ -572,6 +572,7 @@ Route::middleware("auth:sanctum")->group(function () {
         Route::get("/stats", [PurchaseOrderController::class, "getStats"]);
         Route::post("/{autoOrder}/confirm-sent", [PurchaseOrderController::class, "confirmSent"]);
         Route::post('/{autoOrder}/finish', [PurchaseOrderController::class, 'finish']);
+        Route::post("/{autoOrder}/revert-to-sent", [PurchaseOrderController::class, "revertToSent"]);
         Route::get("/", [PurchaseOrderController::class, "getPurchaseOrders"]);
         Route::get("/{autoOrder}/export", [PurchaseOrderController::class, "getExportData"]);
         Route::delete("/{autoOrder}", [PurchaseOrderController::class, "destroy"]);


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Compras: filtro de disponibilidad y revertir órdenes a “Enviada”
<code>✨ Enhancement</code> <code>🐞 Bug fix</code> <code>🕐 40+ Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Agrega filtro “con/sin stock” al asistente IA de compra.
• Permite devolver una orden completada a estado “Enviada” y resetear detalles.
• Corrige consulta de expiraciones para incluir productos eliminados sin el scope global.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  UIA[/"IA Assistant"/] --> AIC["IA Filters API"] --> REPO["AutoOrdersRepository"] --> DB[("DB")]
  UIP[/"Purchase Orders"/] --> POC["PurchaseOrderController"] --> REPO --> DB
  EXP["ExpirationQueryService"] --> DB

  subgraph Legend
    direction LR
    _ui[/"UI"/] ~~~ _svc["Backend/Service"] ~~~ _db[("Database")]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. FormRequest + normalización de filtros</b></summary>

- ➕ Centraliza validación/normalización de hasStock/stock (evita valores inesperados).
- ➕ Reduce lógica condicional en controllers y facilita tests.
- ➖ Agrega clases y wiring adicional para un cambio relativamente pequeño.

</details>

<details>
<summary><b>2. Servicio de transición de estado (state machine)</b></summary>

- ➕ Hace explícitas transiciones permitidas (p.ej. COMPLETED -&gt; SENT) y side-effects.
- ➕ Facilita auditoría, autorización y consistencia entre endpoints.
- ➖ Mayor esfuerzo inicial y refactor de flujos existentes.

</details>

<details>
<summary><b>3. Soft revert por evento/asíncrono</b></summary>

- ➕ Evita latencia en UI si revertir detalles es costoso (muchos detalles).
- ➕ Permite reintentos y logging más robusto.
- ➖ Aumenta complejidad operativa (colas, estados intermedios).

</details>

**Recommendation:** La implementación actual (endpoint + transacción en repositorio) es adecuada para revertir de forma atómica y simple. Como mejora incremental, convendría validar/normalizar hasStock vía FormRequest y considerar un servicio de transiciones si se prevén más cambios de estado con reglas/sidestep similares.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (9)</summary>

<blockquote>
<details>
<summary><strong>SuppliersIaOrderAssistantController.php</strong> <code>Soporte de filtro hasStock en preparación de filtros</code> <code>+4/-0</code></summary>

<br/>

>Soporte de filtro hasStock en preparación de filtros
>
><pre>
>• Agrega el parámetro hasStock y lo convierte a boolean cuando no es &#x27;all&#x27;. Permite filtrar productos por disponibilidad (con/sin stock) desde el asistente IA.
></pre>
>
><a href='https://github.com/Alexiva1995/erp_farmacias/pull/648/files#diff-a5728b4be5d7f5f7eb163bb16ff7db18a8ab008a67a0bd73ef99016cbeb27abc'>app/Http/Controllers/Api/SuppliersIaOrderAssistantController.php</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>PurchaseOrderController.php</strong> <code>Nuevo endpoint para revertir una orden a estado Enviada</code> <code>+5/-0</code></summary>

<br/>

>Nuevo endpoint para revertir una orden a estado Enviada
>
><pre>
>• Añade la acción revertToSent para exponer la reversión de estado vía API. Delegación a AutoOrdersRepository y respuesta JSON simple.
></pre>
>
><a href='https://github.com/Alexiva1995/erp_farmacias/pull/648/files#diff-b4db2bfb46db08c207ad730ef61876f1ccb4f01949ac1ea9e820bf0db0877305'>app/Http/Controllers/PurchaseOrderController.php</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>AutoOrdersRepository.php</strong> <code>Ordenamiento por ID descendente y transacción revertToSent</code> <code>+21/-0</code></summary>

<br/>

>Ordenamiento por ID descendente y transacción revertToSent
>
><pre>
>• Fuerza el ordenamiento de auto_orders por id descendente en applyFilters. Implementa revertToSent en transacción: cambia el status de la orden a SENT y resetea detalles a PENDING con received=null.
></pre>
>
><a href='https://github.com/Alexiva1995/erp_farmacias/pull/648/files#diff-4d8017f3903200534376fe36ab59517b047e09578565809e81db7a2ea39bdb7f'>app/Repository/AutoOrdersRepository.php</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>PurchaseOrdersTable.vue</strong> <code>Acción “Devolver a Enviada” en tabla (desktop y móvil)</code> <code>+28/-0</code></summary>

<br/>

>Acción “Devolver a Enviada” en tabla (desktop y móvil)
>
><pre>
>• Agrega un nuevo evento emit(&#x27;revert&#x27;) y botones visibles sólo cuando status === 2 (completada). Permite disparar la reversión desde la tabla en desktop y en el layout móvil.
></pre>
>
><a href='https://github.com/Alexiva1995/erp_farmacias/pull/648/files#diff-71f215d8ca9125faf6b13b4fbb8d28c67231a6f994668191866dcc3bf653550d'>resources/js/components/PurchaseOrdersTable.vue</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>SupplierIaOrderAssistantFilter.vue</strong> <code>Nuevo selector de disponibilidad (hasStock) y labels consistentes</code> <code>+30/-9</code></summary>

<br/>

>Nuevo selector de disponibilidad (hasStock) y labels consistentes
>
><pre>
>• Incorpora prop/emit v-model para hasStock con opciones con/sin stock y lo considera en hasAdvancedFilters. Sustituye varios placeholders por labels y renombra &#x27;Stock&#x27; a &#x27;Análisis Stock&#x27; para mejorar claridad del formulario.
></pre>
>
><a href='https://github.com/Alexiva1995/erp_farmacias/pull/648/files#diff-16404113a7686a3b36cd8ecfdd13cddeb493ca44b27cd02300541f258597d7ff'>resources/js/components/SupplierIaOrderAssistantFilter.vue</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>PurchaseOrderManagementDialog.vue</strong> <code>Handler de reversión y estado de carga reverting</code> <code>+17/-9</code></summary>

<br/>

>Handler de reversión y estado de carga reverting
>
><pre>
>• Introduce el flag reverting y la acción handleRevertToSent que invoca el nuevo endpoint y refresca datos. Simplifica closeDialog (ya no rechaza pendientes automáticamente al cerrar).
></pre>
>
><a href='https://github.com/Alexiva1995/erp_farmacias/pull/648/files#diff-ef38175ce041b03ad6307906e1ca61ff448090d69fabb1e50fc78c366a4024e1'>resources/js/components/dialogs/PurchaseOrderManagementDialog.vue</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>list.vue</strong> <code>Flujo UI para revertir orden desde el listado</code> <code>+18/-0</code></summary>

<br/>

>Flujo UI para revertir orden desde el listado
>
><pre>
>• Agrega confirmación y llamada axios al endpoint revert-to-sent desde el listado. Conecta el evento @revert de la tabla para refrescar listado y estadísticas.
></pre>
>
><a href='https://github.com/Alexiva1995/erp_farmacias/pull/648/files#diff-cff522b95fa4084e0b2280dc68d2f2750c2cf392168a64ce9aa3e09c838200ba'>resources/js/pages/suppliers/purchase-orders/list.vue</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>supplieriaorderassistant.vue</strong> <code>Propaga hasStock en consultas y reseteo de filtros</code> <code>+5/-0</code></summary>

<br/>

>Propaga hasStock en consultas y reseteo de filtros
>
><pre>
>• Añade estado hasStock, lo resetea en limpiar filtros y lo envía como parámetro en la consulta paginada. Incluye hasStock en el watch para re-consultar al cambiar el filtro.
></pre>
>
><a href='https://github.com/Alexiva1995/erp_farmacias/pull/648/files#diff-22ba8778b2f6b937c2ac6361c9711ed2f1eca9df17c0a53369d9b8fabf71078f'>resources/js/pages/suppliers/supplieriaorderassistant.vue</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>api.php</strong> <code>Nueva ruta POST para revertir órdenes a Enviada</code> <code>+1/-0</code></summary>

<br/>

>Nueva ruta POST para revertir órdenes a Enviada
>
><pre>
>• Registra POST /suppliers/purchase-orders/{autoOrder}/revert-to-sent apuntando a PurchaseOrderController@revertToSent. Expone la capacidad de reversión a UI.
></pre>
>
><a href='https://github.com/Alexiva1995/erp_farmacias/pull/648/files#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6d'>routes/api.php</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>ExpirationQueryService.php</strong> <code>Incluye productos eliminados ignorando el scope not_deleted</code> <code>+1/-1</code></summary>

<br/>

>Incluye productos eliminados ignorando el scope not_deleted
>
><pre>
>• Ajusta la carga de relación product para eliminar explícitamente el global scope &#x27;not_deleted&#x27;. Evita que movimientos de inventario con productos eliminados queden fuera de la consulta de expiraciones.
></pre>
>
><a href='https://github.com/Alexiva1995/erp_farmacias/pull/648/files#diff-922d81d8ceb1ae6de6b5b5c6ed167c2c6a321c20ad1cfcc8779b2e1999532d60'>app/Services/Expirations/ExpirationQueryService.php</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>components.d.ts</strong> <code>Limpieza de tipado global de componente VueApexCharts</code> <code>+0/-1</code></summary>

<br/>

>Limpieza de tipado global de componente VueApexCharts
>
><pre>
>• Elimina la declaración global de VueApexCharts del archivo de typings. Reduce exposición de componentes no usados o ya no registrados globalmente.
></pre>
>
><a href='https://github.com/Alexiva1995/erp_farmacias/pull/648/files#diff-accf53e57f062a60693cf9a4e1fa8b7c09ece40b2cd237fe4681a2c47b2ac961'>components.d.ts</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>